### PR TITLE
feat: add layers for domain entities

### DIFF
--- a/src/main/java/com/example/HPPO_Backend/controllers/BrandsController.java
+++ b/src/main/java/com/example/HPPO_Backend/controllers/BrandsController.java
@@ -1,0 +1,40 @@
+package com.example.HPPO_Backend.controllers;
+
+import com.example.HPPO_Backend.entity.Brand;
+import com.example.HPPO_Backend.entity.dto.BrandRequest;
+import com.example.HPPO_Backend.service.BrandService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("brands")
+public class BrandsController {
+    @Autowired
+    private BrandService brandService;
+
+    @GetMapping
+    public ResponseEntity<Page<Brand>> getBrands(@RequestParam(required = false) Integer page,
+                                                 @RequestParam(required = false) Integer size) {
+        if (page == null || size == null)
+            return ResponseEntity.ok(this.brandService.getBrands(PageRequest.of(0, Integer.MAX_VALUE)));
+        return ResponseEntity.ok(this.brandService.getBrands(PageRequest.of(page, size)));
+    }
+
+    @GetMapping({"/{brandId}"})
+    public ResponseEntity<Brand> getBrandById(@PathVariable Long brandId) {
+        Optional<Brand> result = this.brandService.getBrandById(brandId);
+        return result.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.noContent().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<Object> createBrand(@RequestBody BrandRequest brandRequest) throws Exception {
+        Brand result = this.brandService.createBrand(brandRequest);
+        return ResponseEntity.created(URI.create("/brands/" + result.getId())).body(result);
+    }
+}

--- a/src/main/java/com/example/HPPO_Backend/controllers/CartProductsController.java
+++ b/src/main/java/com/example/HPPO_Backend/controllers/CartProductsController.java
@@ -1,0 +1,40 @@
+package com.example.HPPO_Backend.controllers;
+
+import com.example.HPPO_Backend.entity.CartProduct;
+import com.example.HPPO_Backend.entity.dto.CartProductRequest;
+import com.example.HPPO_Backend.service.CartProductService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("cart-products")
+public class CartProductsController {
+    @Autowired
+    private CartProductService cartProductService;
+
+    @GetMapping
+    public ResponseEntity<Page<CartProduct>> getCartProducts(@RequestParam(required = false) Integer page,
+                                                             @RequestParam(required = false) Integer size) {
+        if (page == null || size == null)
+            return ResponseEntity.ok(this.cartProductService.getCartProducts(PageRequest.of(0, Integer.MAX_VALUE)));
+        return ResponseEntity.ok(this.cartProductService.getCartProducts(PageRequest.of(page, size)));
+    }
+
+    @GetMapping({"/{id}"})
+    public ResponseEntity<CartProduct> getCartProductById(@PathVariable Long id) {
+        Optional<CartProduct> result = this.cartProductService.getCartProductById(id);
+        return result.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.noContent().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<Object> createCartProduct(@RequestBody CartProductRequest request) {
+        CartProduct result = this.cartProductService.createCartProduct(request);
+        return ResponseEntity.created(URI.create("/cart-products/" + result.getId())).body(result);
+    }
+}

--- a/src/main/java/com/example/HPPO_Backend/controllers/CartsController.java
+++ b/src/main/java/com/example/HPPO_Backend/controllers/CartsController.java
@@ -1,0 +1,40 @@
+package com.example.HPPO_Backend.controllers;
+
+import com.example.HPPO_Backend.entity.Cart;
+import com.example.HPPO_Backend.entity.dto.CartRequest;
+import com.example.HPPO_Backend.service.CartService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net URI;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("carts")
+public class CartsController {
+    @Autowired
+    private CartService cartService;
+
+    @GetMapping
+    public ResponseEntity<Page<Cart>> getCarts(@RequestParam(required = false) Integer page,
+                                               @RequestParam(required = false) Integer size) {
+        if (page == null || size == null)
+            return ResponseEntity.ok(this.cartService.getCarts(PageRequest.of(0, Integer.MAX_VALUE)));
+        return ResponseEntity.ok(this.cartService.getCarts(PageRequest.of(page, size)));
+    }
+
+    @GetMapping({"/{cartId}"})
+    public ResponseEntity<Cart> getCartById(@PathVariable Long cartId) {
+        Optional<Cart> result = this.cartService.getCartById(cartId);
+        return result.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.noContent().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<Object> createCart(@RequestBody CartRequest cartRequest) {
+        Cart result = this.cartService.createCart(cartRequest);
+        return ResponseEntity.created(URI.create("/carts/" + result.getId())).body(result);
+    }
+}

--- a/src/main/java/com/example/HPPO_Backend/controllers/CategoriesController.java
+++ b/src/main/java/com/example/HPPO_Backend/controllers/CategoriesController.java
@@ -4,11 +4,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import com.example.HPPO_Backend.entity.Category;
 import com.example.HPPO_Backend.entity.dto.CategoryRequest;
 import com.example.HPPO_Backend.service.CategoryService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
-import java.util.List;
 import java.util.Optional;
 
 @RestController
@@ -21,8 +22,11 @@ public class CategoriesController {
     private CategoryService categoryService;
 
     @GetMapping
-    public ResponseEntity<List<Category>> getCategories() {
-        return ResponseEntity.ok(this.categoryService.getCategories());
+    public ResponseEntity<Page<Category>> getCategories(@RequestParam(required = false) Integer page,
+                                                        @RequestParam(required = false) Integer size) {
+        if (page == null || size == null)
+            return ResponseEntity.ok(this.categoryService.getCategories(PageRequest.of(0, Integer.MAX_VALUE)));
+        return ResponseEntity.ok(this.categoryService.getCategories(PageRequest.of(page, size)));
     }
 
     @GetMapping({"/{categoryId}"})

--- a/src/main/java/com/example/HPPO_Backend/controllers/OrdersController.java
+++ b/src/main/java/com/example/HPPO_Backend/controllers/OrdersController.java
@@ -1,0 +1,40 @@
+package com.example.HPPO_Backend.controllers;
+
+import com.example.HPPO_Backend.entity.Order;
+import com.example.HPPO_Backend.entity.dto.OrderRequest;
+import com.example.HPPO_Backend.service.OrderService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("orders")
+public class OrdersController {
+    @Autowired
+    private OrderService orderService;
+
+    @GetMapping
+    public ResponseEntity<Page<Order>> getOrders(@RequestParam(required = false) Integer page,
+                                                 @RequestParam(required = false) Integer size) {
+        if (page == null || size == null)
+            return ResponseEntity.ok(this.orderService.getOrders(PageRequest.of(0, Integer.MAX_VALUE)));
+        return ResponseEntity.ok(this.orderService.getOrders(PageRequest.of(page, size)));
+    }
+
+    @GetMapping({"/{orderId}"})
+    public ResponseEntity<Order> getOrderById(@PathVariable Long orderId) {
+        Optional<Order> result = this.orderService.getOrderById(orderId);
+        return result.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.noContent().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<Object> createOrder(@RequestBody OrderRequest orderRequest) {
+        Order result = this.orderService.createOrder(orderRequest);
+        return ResponseEntity.created(URI.create("/orders/" + result.getId())).body(result);
+    }
+}

--- a/src/main/java/com/example/HPPO_Backend/controllers/ProductsController.java
+++ b/src/main/java/com/example/HPPO_Backend/controllers/ProductsController.java
@@ -1,0 +1,40 @@
+package com.example.HPPO_Backend.controllers;
+
+import com.example.HPPO_Backend.entity.Product;
+import com.example.HPPO_Backend.entity.dto.ProductRequest;
+import com.example.HPPO_Backend.service.ProductService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("products")
+public class ProductsController {
+    @Autowired
+    private ProductService productService;
+
+    @GetMapping
+    public ResponseEntity<Page<Product>> getProducts(@RequestParam(required = false) Integer page,
+                                                     @RequestParam(required = false) Integer size) {
+        if (page == null || size == null)
+            return ResponseEntity.ok(this.productService.getProducts(PageRequest.of(0, Integer.MAX_VALUE)));
+        return ResponseEntity.ok(this.productService.getProducts(PageRequest.of(page, size)));
+    }
+
+    @GetMapping({"/{productId}"})
+    public ResponseEntity<Product> getProductById(@PathVariable Long productId) {
+        Optional<Product> result = this.productService.getProductById(productId);
+        return result.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.noContent().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<Object> createProduct(@RequestBody ProductRequest productRequest) throws Exception {
+        Product result = this.productService.createProduct(productRequest);
+        return ResponseEntity.created(URI.create("/products/" + result.getId())).body(result);
+    }
+}

--- a/src/main/java/com/example/HPPO_Backend/controllers/UsersController.java
+++ b/src/main/java/com/example/HPPO_Backend/controllers/UsersController.java
@@ -1,0 +1,40 @@
+package com.example.HPPO_Backend.controllers;
+
+import com.example.HPPO_Backend.entity.User;
+import com.example.HPPO_Backend.entity.dto.UserRequest;
+import com.example.HPPO_Backend.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("users")
+public class UsersController {
+    @Autowired
+    private UserService userService;
+
+    @GetMapping
+    public ResponseEntity<Page<User>> getUsers(@RequestParam(required = false) Integer page,
+                                               @RequestParam(required = false) Integer size) {
+        if (page == null || size == null)
+            return ResponseEntity.ok(this.userService.getUsers(PageRequest.of(0, Integer.MAX_VALUE)));
+        return ResponseEntity.ok(this.userService.getUsers(PageRequest.of(page, size)));
+    }
+
+    @GetMapping({"/{userId}"})
+    public ResponseEntity<User> getUserById(@PathVariable Long userId) {
+        Optional<User> result = this.userService.getUserById(userId);
+        return result.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.noContent().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<Object> createUser(@RequestBody UserRequest userRequest) throws Exception {
+        User result = this.userService.createUser(userRequest);
+        return ResponseEntity.created(URI.create("/users/" + result.getId())).body(result);
+    }
+}

--- a/src/main/java/com/example/HPPO_Backend/entity/Brand.java
+++ b/src/main/java/com/example/HPPO_Backend/entity/Brand.java
@@ -1,4 +1,15 @@
 package com.example.HPPO_Backend.entity;
 
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
 public class Brand {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
 }

--- a/src/main/java/com/example/HPPO_Backend/entity/CartProduct.java
+++ b/src/main/java/com/example/HPPO_Backend/entity/CartProduct.java
@@ -5,7 +5,7 @@ import lombok.Data;
 
 @Data
 @Entity
-public class Cart {
+public class CartProduct {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -13,6 +13,9 @@ public class Cart {
     @Column
     private Integer quantity;
 
-    @Column(name = "user_id")
-    private Long userId;
+    @Column(name = "product_id")
+    private Long productId;
+
+    @Column(name = "cart_id")
+    private Long cartId;
 }

--- a/src/main/java/com/example/HPPO_Backend/entity/Order.java
+++ b/src/main/java/com/example/HPPO_Backend/entity/Order.java
@@ -1,10 +1,7 @@
 package com.example.HPPO_Backend.entity;
 
-
 import jakarta.persistence.*;
 import lombok.Data;
-
-import java.util.Date;
 
 @Entity
 @Data
@@ -13,13 +10,15 @@ public class Order {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column
-    private Double total;
+    @Column(nullable = false)
+    private String address;
 
-    @Column
-    private Date date;
+    @Column(nullable = false)
+    private String shipping;
 
-    @Column
+    @Column(name = "cart_id")
+    private Long cartId;
+
+    @Column(name = "user_id")
     private Long userId;
-//pasantias su eb ka utn
 }

--- a/src/main/java/com/example/HPPO_Backend/entity/Product.java
+++ b/src/main/java/com/example/HPPO_Backend/entity/Product.java
@@ -1,4 +1,30 @@
 package com.example.HPPO_Backend.entity;
 
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
 public class Product {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private Double price;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private Integer stock;
+
+    @Column(name = "brand_id")
+    private Long brandId;
+
+    @Column(name = "category_id")
+    private Long categoryId;
 }

--- a/src/main/java/com/example/HPPO_Backend/entity/Role.java
+++ b/src/main/java/com/example/HPPO_Backend/entity/Role.java
@@ -1,4 +1,9 @@
 package com.example.HPPO_Backend.entity;
 
-public class Role {
+/**
+ * Enumeración de roles disponibles para los usuarios del sistema.
+ */
+public enum Role {
+    VENDEDOR,
+    COMPRADOR
 }

--- a/src/main/java/com/example/HPPO_Backend/entity/User.java
+++ b/src/main/java/com/example/HPPO_Backend/entity/User.java
@@ -1,6 +1,5 @@
 package com.example.HPPO_Backend.entity;
 
-
 import jakarta.persistence.*;
 import lombok.Data;
 
@@ -11,18 +10,19 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-
-    @Column
+    @Column(nullable = false)
     private String username;
-    @Column
+
+    @Column(nullable = false)
     private String password;
-    @Column
-    private String email;
-    @Column
-    private String role;
-    @Column
+
+    @Column(nullable = false)
     private String name;
-    @Column
+
+    @Column(nullable = false)
     private String lastName;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
 }

--- a/src/main/java/com/example/HPPO_Backend/entity/dto/BrandRequest.java
+++ b/src/main/java/com/example/HPPO_Backend/entity/dto/BrandRequest.java
@@ -1,0 +1,8 @@
+package com.example.HPPO_Backend.entity.dto;
+
+import lombok.Data;
+
+@Data
+public class BrandRequest {
+    private String name;
+}

--- a/src/main/java/com/example/HPPO_Backend/entity/dto/CartProductRequest.java
+++ b/src/main/java/com/example/HPPO_Backend/entity/dto/CartProductRequest.java
@@ -1,0 +1,10 @@
+package com.example.HPPO_Backend.entity.dto;
+
+import lombok.Data;
+
+@Data
+public class CartProductRequest {
+    private Integer quantity;
+    private Long productId;
+    private Long cartId;
+}

--- a/src/main/java/com/example/HPPO_Backend/entity/dto/CartRequest.java
+++ b/src/main/java/com/example/HPPO_Backend/entity/dto/CartRequest.java
@@ -1,0 +1,9 @@
+package com.example.HPPO_Backend.entity.dto;
+
+import lombok.Data;
+
+@Data
+public class CartRequest {
+    private Integer quantity;
+    private Long userId;
+}

--- a/src/main/java/com/example/HPPO_Backend/entity/dto/OrderRequest.java
+++ b/src/main/java/com/example/HPPO_Backend/entity/dto/OrderRequest.java
@@ -1,0 +1,11 @@
+package com.example.HPPO_Backend.entity.dto;
+
+import lombok.Data;
+
+@Data
+public class OrderRequest {
+    private String address;
+    private String shipping;
+    private Long cartId;
+    private Long userId;
+}

--- a/src/main/java/com/example/HPPO_Backend/entity/dto/ProductRequest.java
+++ b/src/main/java/com/example/HPPO_Backend/entity/dto/ProductRequest.java
@@ -1,0 +1,13 @@
+package com.example.HPPO_Backend.entity.dto;
+
+import lombok.Data;
+
+@Data
+public class ProductRequest {
+    private String name;
+    private Double price;
+    private String description;
+    private Integer stock;
+    private Long brandId;
+    private Long categoryId;
+}

--- a/src/main/java/com/example/HPPO_Backend/entity/dto/UserRequest.java
+++ b/src/main/java/com/example/HPPO_Backend/entity/dto/UserRequest.java
@@ -1,0 +1,13 @@
+package com.example.HPPO_Backend.entity.dto;
+
+import lombok.Data;
+import com.example.HPPO_Backend.entity.Role;
+
+@Data
+public class UserRequest {
+    private String username;
+    private String password;
+    private String name;
+    private String lastName;
+    private Role role;
+}

--- a/src/main/java/com/example/HPPO_Backend/exceptions/BrandDuplicateException.java
+++ b/src/main/java/com/example/HPPO_Backend/exceptions/BrandDuplicateException.java
@@ -1,0 +1,8 @@
+package com.example.HPPO_Backend.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.BAD_REQUEST, reason = "La marca que se intenta agregar esta duplicada")
+public class BrandDuplicateException extends Exception {
+}

--- a/src/main/java/com/example/HPPO_Backend/exceptions/ProductDuplicateException.java
+++ b/src/main/java/com/example/HPPO_Backend/exceptions/ProductDuplicateException.java
@@ -1,0 +1,8 @@
+package com.example.HPPO_Backend.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.BAD_REQUEST, reason = "El producto que se intenta agregar esta duplicado")
+public class ProductDuplicateException extends Exception {
+}

--- a/src/main/java/com/example/HPPO_Backend/exceptions/UserDuplicateException.java
+++ b/src/main/java/com/example/HPPO_Backend/exceptions/UserDuplicateException.java
@@ -1,0 +1,8 @@
+package com.example.HPPO_Backend.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.BAD_REQUEST, reason = "El usuario que se intenta agregar esta duplicado")
+public class UserDuplicateException extends Exception {
+}

--- a/src/main/java/com/example/HPPO_Backend/repository/BrandRepository.java
+++ b/src/main/java/com/example/HPPO_Backend/repository/BrandRepository.java
@@ -1,0 +1,14 @@
+package com.example.HPPO_Backend.repository;
+
+import com.example.HPPO_Backend.entity.Brand;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BrandRepository extends JpaRepository<Brand, Long> {
+    @Query("SELECT b FROM Brand b WHERE b.name = ?1")
+    List<Brand> findByName(String name);
+}

--- a/src/main/java/com/example/HPPO_Backend/repository/CartProductRepository.java
+++ b/src/main/java/com/example/HPPO_Backend/repository/CartProductRepository.java
@@ -1,0 +1,9 @@
+package com.example.HPPO_Backend.repository;
+
+import com.example.HPPO_Backend.entity.CartProduct;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CartProductRepository extends JpaRepository<CartProduct, Long> {
+}

--- a/src/main/java/com/example/HPPO_Backend/repository/CartRepository.java
+++ b/src/main/java/com/example/HPPO_Backend/repository/CartRepository.java
@@ -1,0 +1,9 @@
+package com.example.HPPO_Backend.repository;
+
+import com.example.HPPO_Backend.entity.Cart;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CartRepository extends JpaRepository<Cart, Long> {
+}

--- a/src/main/java/com/example/HPPO_Backend/repository/OrderRepository.java
+++ b/src/main/java/com/example/HPPO_Backend/repository/OrderRepository.java
@@ -1,0 +1,9 @@
+package com.example.HPPO_Backend.repository;
+
+import com.example.HPPO_Backend.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/com/example/HPPO_Backend/repository/ProductRepository.java
+++ b/src/main/java/com/example/HPPO_Backend/repository/ProductRepository.java
@@ -1,0 +1,14 @@
+package com.example.HPPO_Backend.repository;
+
+import com.example.HPPO_Backend.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, Long> {
+    @Query("SELECT p FROM Product p WHERE p.name = ?1")
+    List<Product> findByName(String name);
+}

--- a/src/main/java/com/example/HPPO_Backend/repository/UserRepository.java
+++ b/src/main/java/com/example/HPPO_Backend/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.example.HPPO_Backend.repository;
+
+import com.example.HPPO_Backend.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    @Query("SELECT u FROM User u WHERE u.username = ?1")
+    List<User> findByUsername(String username);
+}

--- a/src/main/java/com/example/HPPO_Backend/service/BrandService.java
+++ b/src/main/java/com/example/HPPO_Backend/service/BrandService.java
@@ -1,0 +1,16 @@
+package com.example.HPPO_Backend.service;
+
+import com.example.HPPO_Backend.entity.Brand;
+import com.example.HPPO_Backend.entity.dto.BrandRequest;
+import com.example.HPPO_Backend.exceptions.BrandDuplicateException;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.Optional;
+
+public interface BrandService {
+    Page<Brand> getBrands(PageRequest pageRequest);
+    Optional<Brand> getBrandById(Long brandId);
+    Brand createBrand(BrandRequest brandRequest) throws BrandDuplicateException;
+}

--- a/src/main/java/com/example/HPPO_Backend/service/BrandServiceImpl.java
+++ b/src/main/java/com/example/HPPO_Backend/service/BrandServiceImpl.java
@@ -1,0 +1,37 @@
+package com.example.HPPO_Backend.service;
+
+import com.example.HPPO_Backend.entity.Brand;
+import com.example.HPPO_Backend.entity.dto.BrandRequest;
+import com.example.HPPO_Backend.exceptions.BrandDuplicateException;
+import com.example.HPPO_Backend.repository.BrandRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class BrandServiceImpl implements BrandService {
+    @Autowired
+    private BrandRepository brandRepository;
+
+    public Page<Brand> getBrands(PageRequest pageRequest) {
+        return brandRepository.findAll(pageRequest);
+    }
+
+    public Optional<Brand> getBrandById(Long brandId) {
+        return brandRepository.findById(brandId);
+    }
+
+    public Brand createBrand(BrandRequest brandRequest) throws BrandDuplicateException {
+        List<Brand> brands = brandRepository.findByName(brandRequest.getName());
+        if (brands.isEmpty()) {
+            Brand brand = new Brand();
+            brand.setName(brandRequest.getName());
+            return brandRepository.save(brand);
+        }
+        throw new BrandDuplicateException();
+    }
+}

--- a/src/main/java/com/example/HPPO_Backend/service/CartProductService.java
+++ b/src/main/java/com/example/HPPO_Backend/service/CartProductService.java
@@ -1,0 +1,15 @@
+package com.example.HPPO_Backend.service;
+
+import com.example.HPPO_Backend.entity.CartProduct;
+import com.example.HPPO_Backend.entity.dto.CartProductRequest;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.Optional;
+
+public interface CartProductService {
+    Page<CartProduct> getCartProducts(PageRequest pageRequest);
+    Optional<CartProduct> getCartProductById(Long id);
+    CartProduct createCartProduct(CartProductRequest request);
+}

--- a/src/main/java/com/example/HPPO_Backend/service/CartProductServiceImpl.java
+++ b/src/main/java/com/example/HPPO_Backend/service/CartProductServiceImpl.java
@@ -1,0 +1,33 @@
+package com.example.HPPO_Backend.service;
+
+import com.example.HPPO_Backend.entity.CartProduct;
+import com.example.HPPO_Backend.entity.dto.CartProductRequest;
+import com.example.HPPO_Backend.repository.CartProductRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class CartProductServiceImpl implements CartProductService {
+    @Autowired
+    private CartProductRepository cartProductRepository;
+
+    public Page<CartProduct> getCartProducts(PageRequest pageRequest) {
+        return cartProductRepository.findAll(pageRequest);
+    }
+
+    public Optional<CartProduct> getCartProductById(Long id) {
+        return cartProductRepository.findById(id);
+    }
+
+    public CartProduct createCartProduct(CartProductRequest request) {
+        CartProduct cp = new CartProduct();
+        cp.setQuantity(request.getQuantity());
+        cp.setProductId(request.getProductId());
+        cp.setCartId(request.getCartId());
+        return cartProductRepository.save(cp);
+    }
+}

--- a/src/main/java/com/example/HPPO_Backend/service/CartService.java
+++ b/src/main/java/com/example/HPPO_Backend/service/CartService.java
@@ -1,0 +1,15 @@
+package com.example.HPPO_Backend.service;
+
+import com.example.HPPO_Backend.entity.Cart;
+import com.example.HPPO_Backend.entity.dto.CartRequest;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.Optional;
+
+public interface CartService {
+    Page<Cart> getCarts(PageRequest pageRequest);
+    Optional<Cart> getCartById(Long cartId);
+    Cart createCart(CartRequest cartRequest);
+}

--- a/src/main/java/com/example/HPPO_Backend/service/CartServiceImpl.java
+++ b/src/main/java/com/example/HPPO_Backend/service/CartServiceImpl.java
@@ -1,0 +1,32 @@
+package com.example.HPPO_Backend.service;
+
+import com.example.HPPO_Backend.entity.Cart;
+import com.example.HPPO_Backend.entity.dto.CartRequest;
+import com.example.HPPO_Backend.repository.CartRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class CartServiceImpl implements CartService {
+    @Autowired
+    private CartRepository cartRepository;
+
+    public Page<Cart> getCarts(PageRequest pageRequest) {
+        return cartRepository.findAll(pageRequest);
+    }
+
+    public Optional<Cart> getCartById(Long cartId) {
+        return cartRepository.findById(cartId);
+    }
+
+    public Cart createCart(CartRequest cartRequest) {
+        Cart cart = new Cart();
+        cart.setQuantity(cartRequest.getQuantity());
+        cart.setUserId(cartRequest.getUserId());
+        return cartRepository.save(cart);
+    }
+}

--- a/src/main/java/com/example/HPPO_Backend/service/CategoryService.java
+++ b/src/main/java/com/example/HPPO_Backend/service/CategoryService.java
@@ -2,11 +2,13 @@ package com.example.HPPO_Backend.service;
 
 import com.example.HPPO_Backend.entity.Category;
 
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
 import java.util.Optional;
 
 public interface CategoryService {
-    public List<Category> getCategories();
+    public Page<Category> getCategories(PageRequest pageRequest);
     public Optional<Category> getCategoryById(Long categoryId);
     public Category createCategory( String description) throws Exception;
 }

--- a/src/main/java/com/example/HPPO_Backend/service/CategoryServiceImpl.java
+++ b/src/main/java/com/example/HPPO_Backend/service/CategoryServiceImpl.java
@@ -4,6 +4,8 @@ import com.example.HPPO_Backend.entity.Category;
 import com.example.HPPO_Backend.exceptions.CategoryDuplicateException;
 import com.example.HPPO_Backend.repository.CategoryRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -15,8 +17,8 @@ public  class CategoryServiceImpl implements CategoryService {
     private CategoryRepository categoryRepository;
 
 
-    public List<Category> getCategories() {
-        return categoryRepository.findAll();
+    public Page<Category> getCategories(PageRequest pageRequest) {
+        return categoryRepository.findAll(pageRequest);
     }
 
     public Optional<Category> getCategoryById(Long categoryId) {

--- a/src/main/java/com/example/HPPO_Backend/service/OrderService.java
+++ b/src/main/java/com/example/HPPO_Backend/service/OrderService.java
@@ -1,0 +1,15 @@
+package com.example.HPPO_Backend.service;
+
+import com.example.HPPO_Backend.entity.Order;
+import com.example.HPPO_Backend.entity.dto.OrderRequest;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.Optional;
+
+public interface OrderService {
+    Page<Order> getOrders(PageRequest pageRequest);
+    Optional<Order> getOrderById(Long orderId);
+    Order createOrder(OrderRequest orderRequest);
+}

--- a/src/main/java/com/example/HPPO_Backend/service/OrderServiceImpl.java
+++ b/src/main/java/com/example/HPPO_Backend/service/OrderServiceImpl.java
@@ -1,0 +1,34 @@
+package com.example.HPPO_Backend.service;
+
+import com.example.HPPO_Backend.entity.Order;
+import com.example.HPPO_Backend.entity.dto.OrderRequest;
+import com.example.HPPO_Backend.repository.OrderRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class OrderServiceImpl implements OrderService {
+    @Autowired
+    private OrderRepository orderRepository;
+
+    public Page<Order> getOrders(PageRequest pageRequest) {
+        return orderRepository.findAll(pageRequest);
+    }
+
+    public Optional<Order> getOrderById(Long orderId) {
+        return orderRepository.findById(orderId);
+    }
+
+    public Order createOrder(OrderRequest orderRequest) {
+        Order newOrder = new Order();
+        newOrder.setAddress(orderRequest.getAddress());
+        newOrder.setShipping(orderRequest.getShipping());
+        newOrder.setCartId(orderRequest.getCartId());
+        newOrder.setUserId(orderRequest.getUserId());
+        return orderRepository.save(newOrder);
+    }
+}

--- a/src/main/java/com/example/HPPO_Backend/service/ProductService.java
+++ b/src/main/java/com/example/HPPO_Backend/service/ProductService.java
@@ -1,0 +1,16 @@
+package com.example.HPPO_Backend.service;
+
+import com.example.HPPO_Backend.entity.Product;
+import com.example.HPPO_Backend.entity.dto.ProductRequest;
+import com.example.HPPO_Backend.exceptions.ProductDuplicateException;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.Optional;
+
+public interface ProductService {
+    Page<Product> getProducts(PageRequest pageRequest);
+    Optional<Product> getProductById(Long productId);
+    Product createProduct(ProductRequest productRequest) throws ProductDuplicateException;
+}

--- a/src/main/java/com/example/HPPO_Backend/service/ProductServiceImpl.java
+++ b/src/main/java/com/example/HPPO_Backend/service/ProductServiceImpl.java
@@ -1,0 +1,42 @@
+package com.example.HPPO_Backend.service;
+
+import com.example.HPPO_Backend.entity.Product;
+import com.example.HPPO_Backend.entity.dto.ProductRequest;
+import com.example.HPPO_Backend.exceptions.ProductDuplicateException;
+import com.example.HPPO_Backend.repository.ProductRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ProductServiceImpl implements ProductService {
+    @Autowired
+    private ProductRepository productRepository;
+
+    public Page<Product> getProducts(PageRequest pageRequest) {
+        return productRepository.findAll(pageRequest);
+    }
+
+    public Optional<Product> getProductById(Long productId) {
+        return productRepository.findById(productId);
+    }
+
+    public Product createProduct(ProductRequest productRequest) throws ProductDuplicateException {
+        List<Product> products = productRepository.findByName(productRequest.getName());
+        if (products.isEmpty()) {
+            Product product = new Product();
+            product.setName(productRequest.getName());
+            product.setPrice(productRequest.getPrice());
+            product.setDescription(productRequest.getDescription());
+            product.setStock(productRequest.getStock());
+            product.setBrandId(productRequest.getBrandId());
+            product.setCategoryId(productRequest.getCategoryId());
+            return productRepository.save(product);
+        }
+        throw new ProductDuplicateException();
+    }
+}

--- a/src/main/java/com/example/HPPO_Backend/service/UserService.java
+++ b/src/main/java/com/example/HPPO_Backend/service/UserService.java
@@ -1,0 +1,16 @@
+package com.example.HPPO_Backend.service;
+
+import com.example.HPPO_Backend.entity.User;
+import com.example.HPPO_Backend.entity.dto.UserRequest;
+import com.example.HPPO_Backend.exceptions.UserDuplicateException;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.Optional;
+
+public interface UserService {
+    Page<User> getUsers(PageRequest pageRequest);
+    Optional<User> getUserById(Long userId);
+    User createUser(UserRequest userRequest) throws UserDuplicateException;
+}

--- a/src/main/java/com/example/HPPO_Backend/service/UserServiceImpl.java
+++ b/src/main/java/com/example/HPPO_Backend/service/UserServiceImpl.java
@@ -1,0 +1,41 @@
+package com.example.HPPO_Backend.service;
+
+import com.example.HPPO_Backend.entity.User;
+import com.example.HPPO_Backend.entity.dto.UserRequest;
+import com.example.HPPO_Backend.exceptions.UserDuplicateException;
+import com.example.HPPO_Backend.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class UserServiceImpl implements UserService {
+    @Autowired
+    private UserRepository userRepository;
+
+    public Page<User> getUsers(PageRequest pageRequest) {
+        return userRepository.findAll(pageRequest);
+    }
+
+    public Optional<User> getUserById(Long userId) {
+        return userRepository.findById(userId);
+    }
+
+    public User createUser(UserRequest userRequest) throws UserDuplicateException {
+        List<User> users = userRepository.findByUsername(userRequest.getUsername());
+        if (users.isEmpty()) {
+            User newUser = new User();
+            newUser.setUsername(userRequest.getUsername());
+            newUser.setPassword(userRequest.getPassword());
+            newUser.setName(userRequest.getName());
+            newUser.setLastName(userRequest.getLastName());
+            newUser.setRole(userRequest.getRole());
+            return userRepository.save(newUser);
+        }
+        throw new UserDuplicateException();
+    }
+}


### PR DESCRIPTION
## Summary
- align user and order entities with role and cart references
- add CRUD controllers, services, and repositories for brand, product, cart, cart-product, user, and order
- represent user roles with `Role` enum
- support pagination on entity listings across controllers and services

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ae32da27588324832cfa4b494fa914