### PR TITLE
Limitar la información que se devuelve al consultar órdenes y establecer una expiración de 24 horas para los carritos

### DIFF
--- a/src/main/java/com/example/HPPO_Backend/controllers/ecom/OrdersController.java
+++ b/src/main/java/com/example/HPPO_Backend/controllers/ecom/OrdersController.java
@@ -5,10 +5,12 @@ import com.example.HPPO_Backend.entity.Order;
 import com.example.HPPO_Backend.entity.User;
 import com.example.HPPO_Backend.entity.dto.CartRequest;
 import com.example.HPPO_Backend.entity.dto.OrderRequest;
+import com.example.HPPO_Backend.entity.dto.OrderResponse;
 import com.example.HPPO_Backend.service.OrderService;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -21,49 +23,58 @@ import java.util.Optional;
 @RestController
 @RequestMapping("orders")
 public class OrdersController {
+	
     @Autowired
     private OrderService orderService;
 
     @GetMapping
-    public ResponseEntity<Page<Order>> getOrders(
+    public ResponseEntity<Page<OrderResponse>> getOrders(
             @RequestParam(required = false) Integer page,
             @RequestParam(required = false) Integer size){
-        if (page == null || size == null)
-            return ResponseEntity.ok(orderService.getOrders(PageRequest.of(0, Integer.MAX_VALUE)));
-        return ResponseEntity.ok(orderService.getOrders(PageRequest.of(page, size)));
+    	
+    	PageRequest pageRequest = (page != null && size != null)
+                ? PageRequest.of(page, size)
+                : PageRequest.of(0, Integer.MAX_VALUE);
+       
+        Page<Order> orders = orderService.getOrders(pageRequest);
+        Page<OrderResponse> dtoPage = orders.map(OrderResponse::fromOrder);
+        return ResponseEntity.ok(dtoPage);
     }
 
     @GetMapping({"/{orderId}"})
-    public ResponseEntity<Order> getOrderById(@PathVariable Long orderId) {
+    public ResponseEntity<OrderResponse> getOrderById(@PathVariable Long orderId) {
         Optional<Order> result = this.orderService.getOrderById(orderId);
-        return result.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.noContent().build());
+        return result.map(order -> ResponseEntity.ok(OrderResponse.fromOrder(order))).orElseGet(() -> ResponseEntity.noContent().build());
     }
     @PutMapping("/{orderId}")
-    public ResponseEntity<Order> updateOrder(
+    public ResponseEntity<OrderResponse> updateOrder(
             @PathVariable Long orderId,
             @RequestBody OrderRequest orderRequest,
             @AuthenticationPrincipal User user) {
         Order updatedOrder = this.orderService.updateOrder(orderId, orderRequest, user);
-        return ResponseEntity.ok(updatedOrder);
+        return ResponseEntity.ok(OrderResponse.fromOrder(updatedOrder));
     }
 
 
     @PostMapping
-    public ResponseEntity<Object> createOrder(
+    public ResponseEntity<OrderResponse> createOrder(
             @RequestBody OrderRequest orderRequest,
             @AuthenticationPrincipal User user) {
         Order result = this.orderService.createOrder(orderRequest, user);
-        return ResponseEntity.created(URI.create("/orders/" + result.getId())).body(result);
+        return ResponseEntity
+        		.created(URI.create("/orders/" + result.getId()))
+        		.body(OrderResponse.fromOrder(result));
     }
+    
     @PatchMapping("/{orderId}/cancel")
-    public ResponseEntity<Order> cancelOrder(@PathVariable Long orderId, @AuthenticationPrincipal User user) {
+    public ResponseEntity<OrderResponse> cancelOrder(@PathVariable Long orderId, @AuthenticationPrincipal User user) {
         Order cancelledOrder = this.orderService.cancelOrder(orderId, user);
-        return ResponseEntity.ok(cancelledOrder);
+        return ResponseEntity.ok(OrderResponse.fromOrder(cancelledOrder));
 
     }
 
     @GetMapping("/my-orders")
-    public ResponseEntity<Page<Order>> getMyOrders(
+    public ResponseEntity<Page<OrderResponse>> getMyOrders(
             @RequestParam(required = false) Integer page,
             @RequestParam(required = false) Integer size,
             @AuthenticationPrincipal User user) {
@@ -73,6 +84,7 @@ public class OrdersController {
                 : PageRequest.of(0, Integer.MAX_VALUE);
 
         Page<Order> myOrders = orderService.getMyOrders(user, pageRequest);
+        Page<OrderResponse> dtoPage = myOrders.map(OrderResponse::fromOrder);
         return ResponseEntity.ok(myOrders);
     }
 

--- a/src/main/java/com/example/HPPO_Backend/entity/Cart.java
+++ b/src/main/java/com/example/HPPO_Backend/entity/Cart.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Data;
 import java.util.List;
+import java.time.LocalDateTime;
 
 @Entity
 @Data
@@ -21,6 +22,18 @@ public class Cart {
 
     @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CartProduct> items;
+    
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
 
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @PrePersist
+    public void prePersist() {
+        if (createdAt == null) createdAt = LocalDateTime.now();
+        if (expiresAt == null) expiresAt = createdAt.plusHours(24); // Para que el carrito expire en 24hs
+        }
+    }
 
 }

--- a/src/main/java/com/example/HPPO_Backend/entity/dto/OrderItemResponse.java
+++ b/src/main/java/com/example/HPPO_Backend/entity/dto/OrderItemResponse.java
@@ -1,0 +1,31 @@
+package com.example.HPPO_Backend.entity.dto;
+
+public class OrderItemResponse {
+    private Long productId;
+    private String productName;
+    private Integer quantity;
+    private Double price;
+    private Integer discount;
+
+    public OrderItemResponse() {}
+
+    public OrderItemResponse(Long productId, String productName,
+                             Integer quantity, Double price, Integer discount) {
+        this.productId = productId;
+        this.productName = productName;
+        this.quantity = quantity;
+        this.price = price;
+        this.discount = discount;
+    }
+
+    public Long getProductId() { return productId; }
+    public void setProductId(Long productId) { this.productId = productId; }
+    public String getProductName() { return productName; }
+    public void setProductName(String productName) { this.productName = productName; }
+    public Integer getQuantity() { return quantity; }
+    public void setQuantity(Integer quantity) { this.quantity = quantity; }
+    public Double getPrice() { return price; }
+    public void setPrice(Double price) { this.price = price; }
+    public Integer getDiscount() { return discount; }
+    public void setDiscount(Integer discount) { this.discount = discount; }
+}

--- a/src/main/java/com/example/HPPO_Backend/entity/dto/OrderResponse.java
+++ b/src/main/java/com/example/HPPO_Backend/entity/dto/OrderResponse.java
@@ -1,0 +1,62 @@
+package com.example.HPPO_Backend.entity.dto;
+
+import com.example.HPPO_Backend.entity.Order;
+import com.example.HPPO_Backend.entity.OrderItem;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class OrderResponse {
+    private Long id;
+    private String address;
+    private String shipping;
+    private Double total;
+    private LocalDateTime orderDate;
+    private String status;
+    private List<OrderItemResponse> items;
+
+    public OrderResponse() {}
+
+    public static OrderResponse fromOrder(Order order) {
+        OrderResponse dto = new OrderResponse();
+        dto.id = order.getId();
+        dto.address = order.getAddress();
+        dto.shipping = order.getShipping();
+        dto.total = order.getTotal();
+        dto.orderDate = order.getOrderDate();
+        dto.status = order.getStatus() != null ? order.getStatus().name() : null;
+
+        dto.items = order.getItems().stream()
+                .map(OrderResponse::mapItem)
+                .collect(Collectors.toList());
+
+        return dto;
+    }
+
+    private static OrderItemResponse mapItem(OrderItem item) {
+        return new OrderItemResponse(
+                item.getProduct().getId(),
+                item.getProduct().getName(),
+                item.getQuantity(),
+                item.getPrice(),
+                item.getProduct().getDiscount()
+        );
+    }
+
+    public Long getId() { return id; }
+    public String getAddress() { return address; }
+    public String getShipping() { return shipping; }
+    public Double getTotal() { return total; }
+    public LocalDateTime getOrderDate() { return orderDate; }
+    public String getStatus() { return status; }
+    public List<OrderItemResponse> getItems() { return items; }
+
+    public void setId(Long id) { this.id = id; }
+    public void setAddress(String address) { this.address = address; }
+    public void setShipping(String shipping) { this.shipping = shipping; }
+    public void setTotal(Double total) { this.total = total; }
+    public void setOrderDate(LocalDateTime orderDate) { this.orderDate = orderDate; }
+    public void setStatus(String status) { this.status = status; }
+    public void setItems(List<OrderItemResponse> items) { this.items = items; }
+}


### PR DESCRIPTION
Filtrar la información devuelta al obtener órdenes (devolviendo  datos esenciales de cada producto) y añadir un sistema de expiración del carrito pasado un período de 24 horas. 